### PR TITLE
Check for dependency lock file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,22 +11,42 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Detect project layout
+        id: detect
+        shell: bash
+        run: |
+          if [ -f frontend/package-lock.json ]; then
+            echo "LOCKFILE_PATH=frontend/package-lock.json" >> $GITHUB_ENV
+            echo "WORKDIR=frontend" >> $GITHUB_ENV
+            echo "ARTIFACT_PATH=frontend/build" >> $GITHUB_ENV
+          elif [ -f package-lock.json ]; then
+            echo "LOCKFILE_PATH=package-lock.json" >> $GITHUB_ENV
+            echo "WORKDIR=." >> $GITHUB_ENV
+            echo "ARTIFACT_PATH=.next" >> $GITHUB_ENV
+          else
+            echo "LOCKFILE_PATH=package-lock.json" >> $GITHUB_ENV
+            echo "WORKDIR=." >> $GITHUB_ENV
+            echo "ARTIFACT_PATH=.next" >> $GITHUB_ENV
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: ${{ env.LOCKFILE_PATH }}
 
       - name: Install dependencies
         run: npm ci
+        working-directory: ${{ env.WORKDIR }}
 
       - name: Build
         run: npm run build
+        working-directory: ${{ env.WORKDIR }}
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         if: success()
         with:
-          name: next-build
-          path: .next
+          name: web-build
+          path: ${{ env.ARTIFACT_PATH }}


### PR DESCRIPTION
Add GitHub Actions workflow for frontend build, resolving the lockfile not found error.

The previous CI run failed because it couldn't find `package-lock.json` in the repository root. This workflow configures the CI to run within the `frontend` directory and correctly points the dependency cache to `frontend/package-lock.json`.

---
<a href="https://cursor.com/background-agent?bcId=bc-69c6cfb4-5961-422d-8239-02dc700745c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-69c6cfb4-5961-422d-8239-02dc700745c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

